### PR TITLE
added bibliography

### DIFF
--- a/vignettes/hexagon_binning.Rnw
+++ b/vignettes/hexagon_binning.Rnw
@@ -12,6 +12,8 @@
 \usepackage{amsmath}
 \usepackage{hyperref}
 
+\usepackage[backend=bibtex]{biblatex}
+\bibliography{references}
 
 \author{Nicholas Lewin-Koh\footnote{with minor assistance by Martin M\"achler}}
 
@@ -62,12 +64,12 @@ squares. This property translates into better sampling efficiency at
 least for elliptical shapes. Lastly hexagons are visually less biased
 for displaying densities than other regular tesselations. For instance
 with squares our eyes are drawn to the horizontal and vertical lines
-of the grid. The following figure adapted from \cite[]{carretal}shows
-this effectively. 
+of the grid. The following figure adapted from \cite{carretal} shows
+this effectively.
 
 \begin{figure}[h]
   \centering
-<<comphexsq, fig=TRUE, width=7, height=4, echo=FALSE>>=
+<<comphexsq, fig.width=7, fig.height=4, echo=FALSE>>=
 library("grid")
 library("hexbin")
 x <- rnorm(1000)
@@ -111,7 +113,7 @@ popViewport()
 \end{figure}
 
 
-We can see in Figure~\ref{fig:compHexSq} that when the data are plotted 
+We can see in Figure~\ref{fig:compHexSq} that when the data are plotted
 as squares centered on a regular lattice our eye is drawn to the regular lines
 which are parallel to the underlying grid. Hexagons tend to break up
 the lines.
@@ -126,7 +128,7 @@ How does does the hexagon binning algorithm work?
 \end{enumerate}
 
 
-<< nearNeighbor, echo = false, results = hide >>=
+<< nearNeighbor, echo = FALSE, results = 'hide' >>=
 x <- -2:2
 sq <- expand.grid(list(x = x, y = c(-1,0,1)))
 fc.sq   <- rbind(sq,sq+.5)                 # face centered squares
@@ -136,7 +138,7 @@ nr <- length(fc.sq$x)/2
 
 \begin{figure}[h]
   \centering
-<< fig = TRUE,width = 4,height = 8,echo = FALSE >>=
+<<fig.width=4, fig.height=8, echo = FALSE >>=
 par(mfrow = c(3,1))
 par(mai = c(.1667,0.2680,0.1667,0.2680)) ##par(mai=.25*par("mai"))
 plot(fc.sq$x, fc.sq$y, pch = 16, cex = .5)
@@ -171,7 +173,7 @@ plot.new()
 arrows(-.25, .15, 0, 0, angle = 10, length = .05)
 @
 \caption[Near Neighbor Rectangles]{}
-\label{fig:binalg}
+  \label{fig:binalg}
 \end{figure}
 
 Figure~\ref{fig:binalg} shows graphically how the algorithm works. In
@@ -192,7 +194,7 @@ than using the basic plotting functions. The following little example
 shows the basic features of the basic plot and binning functions.
 We start by loading the package and generating a toy example data set.
 
-<< basic, fig = TRUE, results = hide >>=
+<< basic, results = 'hide' >>=
 x <- rnorm(20000)
 y <- rnorm(20000)
 hbin <- hexbin(x,y, xbins = 40)
@@ -207,7 +209,7 @@ argument \texttt{n} and returns $n$ colors.  Several functions are supplied
 that provide alternative color-ramps to R's built in color ramp functions,
 see \texttt{help(ColorRamps)}.
 
-<< showcol, fig = TRUE, width = 7, height = 4, echo = FALSE >>=
+<< showcol, fig.width=7, fig.height=4, echo = FALSE >>=
 #nf <- layout(matrix(c(1,1,2,2,4,3,3,4), ncol=4, nrow=2, byrow=TRUE),
 #          widths = rep(1,4), heights=rep(1,2))
 grid.newpage()
@@ -283,7 +285,7 @@ first and second order neighbors specified as \texttt{c(48,24,12)}.
 The code segment generating these plots rescales the smoothed counts
 so that they are on the original scale.
 
-<< showsmth, fig = TRUE, width = 8, height = 4, echo = FALSE >>=
+<< showsmth, fig.width=8, fig.height=4, echo = FALSE >>=
 #nf <- layout(matrix(c(1,1,2,2,4,3,3,4), ncol=4, nrow=2, byrow=TRUE),
 #          widths = rep(1,4), heights=rep(1,2))
 x <- rnorm(10000)
@@ -356,7 +358,7 @@ vpin <- c(unit(6,"inches"),unit(4, "inches"))
 shape <- optShape(height = vpin[2], width = vpin[1], mar = mai)
 @
 
-<< hbox, fig = TRUE, width = 6, height = 4, echo = FALSE >>=
+<< hbox, fig.width=6, fig.height=4, echo = FALSE >>=
 hb <- hexbin(NHANES$Transferin, NHANES$Hemoglobin, shape = shape)
 hbhp <- hboxplot(erode(hb,cdfcut = .05),unzoom = 1.3)
 pushHexport(hbhp,clip = 'on')
@@ -387,7 +389,7 @@ calculate the bivariate medians, and only display the upper 75\% of
 the data.
 \begin{figure}[h]
   \centering
-<< hdiff, fig = TRUE, width = 6, height = 4, echo = TRUE >>=
+<< hdiff, fig.width=6, fig.height=4, echo = TRUE >>=
 #grid.newpage()
 shape <- optShape(height = vpin[2],width = vpin[1],mar = mai)
 xbnds <- range(NHANES$Transferin,na.rm = TRUE)
@@ -418,7 +420,7 @@ summarize values for each hexagon according to the supplied function
 and return the table in the right order to use as an attribute
 vector. Another alternative is to set the \texttt{cAtt} slot of the
 hexbin object and grid.hexagons will automatically plot the attribute
-if \texttt{use.count = FALSE} and \texttt{cell.at = NULL}. 
+if \texttt{use.count = FALSE} and \texttt{cell.at = NULL}.
 
 Here is an example using spatial data. Often cartographers use
 graduated symbols to display varying numerical quantities across a region.
@@ -441,7 +443,7 @@ are well below zero, and that the overall shape is more like a comet
 with most of the mass at the bottom of the curve, rather than a thick
 bar of points curving below the line.
 
-<< marray1, fig = TRUE, results = hide >>=
+<< marray1, results = 'hide' >>=
 ### Need to redo this part.
 if (require("marray")) {
 data(swirl, package = "marray") ## use swirl dataset
@@ -491,7 +493,7 @@ create a custom plotting function using \texttt{hexViewport} and grid.
 \subsection{Adding to an existing plot}
 Adding to an existing plot requires the use of grid
 functions. For instance, in the following code,
-<< addto,fig = TRUE,echo = TRUE >>=
+<< addto, echo = TRUE >>=
 if (require("marray")) {
 hplt <- plot(hb1, style = 'centroid', border = gray(.65))
 pushHexport(hplt$plot.vp)
@@ -503,7 +505,9 @@ grid.lines(pseq, predict(ll.fit,pseq),
 	plot(1)
 }
 @
+
 we have to use \texttt{grid.lines()}, as opposed to \texttt{lines()}.
 
+\printbibliography
 
 \end{document}

--- a/vignettes/hexagon_binning.Rnw
+++ b/vignettes/hexagon_binning.Rnw
@@ -128,7 +128,7 @@ How does does the hexagon binning algorithm work?
 \end{enumerate}
 
 
-<< nearNeighbor, echo = FALSE, results = 'hide' >>=
+<< nearNeighbor, echo = FALSE, results = hide >>=
 x <- -2:2
 sq <- expand.grid(list(x = x, y = c(-1,0,1)))
 fc.sq   <- rbind(sq,sq+.5)                 # face centered squares

--- a/vignettes/references.bib
+++ b/vignettes/references.bib
@@ -1,0 +1,11 @@
+@article{carretal,
+  author = {Daniel B. Carr and Anthony R. Olsen and Denis White},
+  title = {Hexagon Mosaic Maps for Display of Univariate and Bivariate Geographical Data},
+  journal = {Cartography and Geographic Information Systems},
+  volume = {19},
+  number = {4},
+  pages = {228-236},
+  year  = {1992},
+  publisher = {Taylor & Francis},
+  doi = {10.1559/152304092783721231}
+}


### PR DESCRIPTION
Fixes #9 but in my environment I do not get the "Figure 2:" label for the second figure anymore (the caption was missing because left empty in the source).

I also noticed that all Figure label numbering/captions are missing but for the first one.

Note: I haven't touched the (looks like related) files under `inst/doc`.
(I have to say that Rnw looks much harder than Rmd, but Rnw was probably what was available 5 years ago)

Please let me know whether anything else is needed...