### PR TITLE
Added drop=FALSE to LINGRAY so that you can plot hexbin objects with …

### DIFF
--- a/R/LINGRAY.R
+++ b/R/LINGRAY.R
@@ -103,7 +103,7 @@ LinGray <- function(n,beg = 1,end = 92)
 	       c(245,245,245),
 	       c(252,252,252),
 	       c(255,255,255),
-	       c(255,255,255))[round(seq(beg,end,length = n)), ]
+	       c(255,255,255))[round(seq(beg,end,length = n)), , drop=FALSE]
 
     rgb(M[,1]/255,
 	M[,2]/255,


### PR DESCRIPTION
…only one color hexagon (all occupied hexagons have the same count)

Very simple change to LinGray that prevents the error M[ ,1] incorrect number of dimensions when all cells have the same count value.

This change worked to allow the plot of a hexbin object that had thrown an error for me before.