### PR TITLE
Additional graphical parameters for loess lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: hexbin
-Version: 1.28.1
+Version: 1.28.2
 Title: Hexagonal Binning Routines
 Author: Dan Carr <dcarr@voxel.galaxy.gmu.edu>, ported by Nicholas
         Lewin-Koh and Martin Maechler <maechler@stat.math.ethz.ch>,
@@ -18,3 +18,4 @@ License: GPL-2
 VignetteBuilder: knitr
 NeedsCompilation: yes
 URL: http://github.com/edzer/hexbin
+RoxygenNote: 7.1.1

--- a/R/hexPlotMA.R
+++ b/R/hexPlotMA.R
@@ -189,8 +189,8 @@ plotMAhex <- function (MA, array = 1, xlab = "A", ylab = "M",
     invisible(list(hbin = hbin, plot.vp = hp$plot.vp, legend.vp = hp$legend.vp))
 }
 
-hexMA.loess <- function(pMA, span = .4, col = 'red', n = 200)
+hexMA.loess <- function (pMA, span = 0.4, n = 200, ...) 
 {
-  fit <- hexVP.loess(pMA$hbin, pMA$plot.vp, span = span, col = col, n = n)
-  invisible(fit)
+    fit <- hexVP.loess(pMA$hbin, pMA$plot.vp, span = span, n = n, ...)
+    invisible(fit)
 }

--- a/R/hexViewport.R
+++ b/R/hexViewport.R
@@ -241,18 +241,19 @@ hexVP.abline <- function(hvp, a = NULL, b = NULL, h = numeric(0),
     popViewport()
 }
 
-hexVP.loess <- function(hbin, hvp = NULL, span = 0.4, col = 'red', n = 200)
-{
+hexVP.loess <- function (hbin, hvp = NULL, span = 0.4, n = 200, ...) 
+  {
+    dots <- list(...)
+    if(is.null(dots$col)) dots$col <- "red" 
+    gp <- do.call(gpar, dots)
+  
     fit <- loess(hbin@ycm ~ hbin@xcm, weights = hbin@count, span = span)
-    if(!is.null(hvp)) {
-        pushHexport(hvp, clip = 'on')
-#        grid.lines(seq(0,16, length = n),
-#                   predict(fit,seq(0,16, length = n)),
-#                   gp = gpar(col = col), default.units = 'native')
- 		grid.lines(seq(hbin@xbnds[1], hbin@xbnds[2], length = n),
-				predict(fit,seq(hbin@xbnds[1], hbin@xbnds[2], length = n)),
-				gp = gpar(col = col), default.units = 'native')
+    if (!is.null(hvp)) {
+        pushHexport(hvp, clip = "on")
+        grid.lines(seq(hbin@xbnds[1], hbin@xbnds[2], length = n), 
+            predict(fit, seq(hbin@xbnds[1], hbin@xbnds[2], length = n)), 
+            gp = gp, default.units = "native")
         popViewport()
     }
     invisible(fit)
-}
+  }

--- a/man/hexMA.loess.Rd
+++ b/man/hexMA.loess.Rd
@@ -7,8 +7,8 @@
   coordinates and the cell counts as weights.
 }
 \usage{
-hexMA.loess(pMA, span = 0.4, col = "red", n = 200)
-hexVP.loess(hbin, hvp = NULL, span = 0.4, col = "red", n = 200)
+hexMA.loess(pMA, span = 0.4, n = 200, ...)
+hexVP.loess(hbin, hvp = NULL, span = 0.4, n = 200, ...)
 }
 
 \arguments{
@@ -16,8 +16,8 @@ hexVP.loess(hbin, hvp = NULL, span = 0.4, col = "red", n = 200)
   \item{hvp}{A \code{hexViewport} object.}
   \item{pMA}{the list returned by \code{\link{plotMAhex}}.}
   \item{span}{the parameter alpha which controls the degree of smoothing.}
-  \item{col}{line color for the loess fit.}
   \item{n}{number of points at which the fit should be evaluated.}
+  \item{...}{Additional graphical parameter settings for the \code{loess} line fit; see \code{\link[grid]{gpar}}. The line colour defaults to red.}
 }
 \value{
   Returns invisibly the object associated with the loess fit.
@@ -37,6 +37,11 @@ hexVP.loess(hbin, hvp = NULL, span = 0.4, col = "red", n = 200)
     hexVP.abline(hb$plot, h=0, col= gray(.6))
     hexMA.loess(hb)
   }
+
+  dat <- data.frame(x=rnorm(1000), y=rnorm(1000))
+  bin <- hexbin(dat$x, dat$y)
+  hb <- plot(bin)
+  hexVP.loess(bin, hvp = hb$plot.vp, span = 0.4, n = 200, col = "blue", lwd = 3, lty = "dashed")
 }
 \keyword{aplot}
 


### PR DESCRIPTION
Hi,
Re https://github.com/edzer/hexbin/issues/16. 
This pull allows for additional graphical parameters to be passed to `hexMA.loess` and `hexVP.loess`. Documentation has been updated and an additional example given. Minor version number has been incremented.